### PR TITLE
Bump version to 0.0.1.5, skip 0.0.1.4 as we were using that internally

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    camaleon_oauth (0.0.1.3)
+    camaleon_oauth (0.0.1.5)
       active_model_serializers (= 0.9.2)
       doorkeeper (~> 3.0)
       faraday (~> 0.9.2)

--- a/lib/camaleon_oauth/version.rb
+++ b/lib/camaleon_oauth/version.rb
@@ -1,3 +1,3 @@
 module CamaleonOauth
-  VERSION = '0.0.1.3'
+  VERSION = '0.0.1.5'
 end


### PR DESCRIPTION
It looks like camaleon_oauth is not on rubygems.org making it uninstallable via standard Gemfile procedures. Furthermore it looks like we had a version "0.0.1.4" locally.

This PR bumps version to 0.0.1.5, and it would be great to get the library on rubygems.org after this PR is merged.
